### PR TITLE
Split the API to present the two legs of protocol separately

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥64.5%
+name: cover ≥71.5%
 on: [push]
 jobs:
 

--- a/doc.go
+++ b/doc.go
@@ -5,7 +5,10 @@
 Package apiclient implements the interaction model described in
 https://github.com/veraison/veraison/tree/main/docs/api
 
-Challenge-Response
+Challenge-Response, atomic operation
+
+Using this mode of operation the whole API client exchange is handled
+atomically through a single invocation of the Run() method.
 
 The user provides the Evidence generation logics by implementing the
 EvidenceBuilder interface:
@@ -71,5 +74,51 @@ On success, the Attestation Result, is returned as a JSON string:
 		fmt.Println("%s", string(attestationResult))
 	}
 
+Challenge-Response, split operation
+
+Using this mode of operation the client is responsible for dealing with each
+API call separately, invoking the right API method at the right time and place.
+
+In this mode, users does not provide the Evidence generation logics through
+the EvidenceBuilder interface. Instead, they will need to plug in their
+Evidence building logics between the call to NewSession() and the subsequent
+ChallengeResponse().
+
+Similarly to the atomic operation case, users create a
+ChallengeResponseConfig object supplying either an explicit nonce or the
+requested nonce size, and any other applicable configuration parameter, e.g., a
+custom Client:
+
+	cfg := ChallengeResponseConfig{
+		Nonce:         []byte{0xde, 0xad, 0xbe, 0xef},
+		NewSessionURI: "http://veraison.example/challenge-response/v1/newSession",
+		Client: &Client{
+			HTTPClient: http.Client{
+				Transport: myTLSConfig,
+			},
+		},
+	}
+
+Same as the atomic model, users can also request to explicitly delete the
+session resource on the server instead of letting it expire by setting the
+DeleteSession configuration parameter to true.
+
+The NewSession() method is then invoked on the instantiated
+ChallengeReponseConfig object to trigger the creation of a new session
+resource on the server:
+
+	newSessionCtx, sessionURI, err := cfg.NewSession()
+
+Users need to use the nonce returned in newSessionCtx.Nonce to trigger a
+challenge-response session with the Attester and obtain the Evidence. Users
+will typically make use of the acceptable Evidence formats advertised by the
+server in newSessionCtx.Accept as an additional input to the protocol with
+the Attester.
+
+When the Evidence has been obtained, the ChallengeResponse() method can be
+invoked to submit it to the allocated session with the Verifier that, on
+success, will return the Attestation Result:
+
+	attestationResult, err := cfg.ChallengeResponse(evidence, mediaType, sessionURI)
 */
 package apiclient


### PR DESCRIPTION
Also, bump up the coverage threshold a bit.

Fixes #3