### PR TITLE
Implement management API support

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,16 +7,16 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env: 
+    env:
      GO111MODULE: on
     steps:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.18"
+        go-version: "1.19"
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install golangci-lint 
+    - name: Install golangci-lint
       run: |
         go version
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0

--- a/common/client.go
+++ b/common/client.go
@@ -30,9 +30,7 @@ func (c Client) DeleteResource(uri string) error {
 		return fmt.Errorf("DELETE %q, request creation failed: %w", uri, err)
 	}
 
-	hc := &c.HTTPClient
-
-	res, err := hc.Do(req)
+	res, err := c.send(req)
 	if err != nil {
 		return err
 	}
@@ -55,6 +53,32 @@ func (c Client) PostResource(body []byte, ct, accept, uri string) (*http.Respons
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("Accept", accept)
 
+	return c.send(req)
+}
+
+func (c Client) PostEmptyResource(accept, uri string) (*http.Response, error) {
+	req, err := http.NewRequest("POST", uri, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("POST %q, request creation failed: %w", uri, err)
+	}
+
+	req.Header.Set("Accept", accept)
+
+	return c.send(req)
+}
+
+func (c Client) GetResource(accept, uri string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", uri, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("POST %q, request creation failed: %w", uri, err)
+	}
+
+	req.Header.Set("Accept", accept)
+
+	return c.send(req)
+}
+
+func (c Client) send(req *http.Request) (*http.Response, error) {
 	hc := &c.HTTPClient
 
 	res, err := hc.Do(req)

--- a/common/problem.go
+++ b/common/problem.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/moogar0880/problems"
+)
+
+type ProblemError struct {
+	problems.DefaultProblem
+}
+
+func (o *ProblemError) Error() string {
+	return fmt.Sprintf("%d %s: %s", o.ProblemStatus(), o.ProblemTitle(), o.Detail)
+}
+
+func CheckResponse(res *http.Response, expected ...int) error {
+	for _, exp := range expected {
+		if res.StatusCode == exp {
+			return nil
+		}
+	}
+
+	if res.Header.Get("Content-Type") == problems.ProblemMediaType {
+		var prob ProblemError
+
+		if err := DecodeJSONBody(res, &prob.DefaultProblem); err != nil {
+			return fmt.Errorf(
+				"could not decode problem response (status %d): %w",
+				res.StatusCode,
+				err,
+			)
+		}
+
+		return &prob
+	}
+
+	return fmt.Errorf("unexpected HTTP response code %d", res.StatusCode)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/veraison/apiclient
 
-go 1.18
+go 1.19
 
 require (
+	github.com/google/uuid v1.3.0
+	github.com/moogar0880/problems v0.1.1
 	github.com/stretchr/testify v1.8.2
 	github.com/veraison/cmw v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/moogar0880/problems v0.1.1 h1:bktLhq8NDG/czU2ZziYNigBFksx13RaYe5AVdNmHDT4=
+github.com/moogar0880/problems v0.1.1/go.mod h1:5Dxrk2sD7BfBAgnOzQ1yaTiuCYdGPUh49L8Vhfky62c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/management/management.go
+++ b/management/management.go
@@ -1,0 +1,273 @@
+// Copyright 2023 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package management
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/google/uuid"
+	"github.com/veraison/apiclient/common"
+)
+
+const (
+	OPARulesMediaType  = "application/vnd.veraison.policy.opa"
+	PolicyMediaType    = "application/vnd.veraison.policy+json"
+	PoliciesMediaType  = "application/vnd.veraison.policies+json"
+	WellKnownMediaType = "application/vnd.veraison.discovery+json"
+
+	WellKnownPath = "/.well-known/veraison/management"
+)
+
+// Service is the primary interface to the management service API.
+type Service struct {
+	// Client is the underlying client used for HTTP requests.
+	Client *common.Client
+
+	// EndPointURI is the top-level service API URL. Individual operations
+	// endpoints are relative to this.
+	EndPointURI *url.URL
+}
+
+// NewService creates a new Service instance using the provided endpoint
+// URI and the default HTTP client.
+func NewService(uri string) (*Service, error) {
+	m := Service{Client: common.NewClient()}
+
+	if err := m.SetEndpointURI(uri); err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+// SetClient sets the HTTP(s) client connection configuration
+func (o *Service) SetClient(client *common.Client) error {
+	if client == nil {
+		return errors.New("no client supplied")
+	}
+	o.Client = client
+	return nil
+}
+
+// SetEndpointURI sets the URI if the Veraison services management endpoint.
+func (o *Service) SetEndpointURI(uri string) error {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("malformed URI: %w", err)
+	}
+
+	if !u.IsAbs() {
+		return fmt.Errorf("URI is not absolute: %q", uri)
+	}
+
+	o.EndPointURI = u
+
+	return nil
+}
+
+// CreateOPAPolicy is a wrapper around CreatePolicy that assumes the OPA media
+// type.
+func (o *Service) CreateOPAPolicy(scheme string, rules []byte, name string) (*Policy, error) {
+	return o.CreatePolicy(scheme, OPARulesMediaType, rules, name)
+}
+
+// CreatePolicy creates a new policy associated with the specified scheme based
+// on the specified content type and rules, with the specified name.
+func (o *Service) CreatePolicy(
+	scheme string,
+	ct string,
+	rules []byte,
+	name string,
+) (*Policy, error) {
+	postURI := o.EndPointURI.JoinPath("policy", scheme)
+
+	qvals := url.Values{}
+	if name != "" {
+		qvals.Add("name", name)
+	}
+	postURI.RawQuery = qvals.Encode()
+
+	res, err := o.Client.PostResource(rules, ct, PolicyMediaType, postURI.String())
+	if err != nil {
+		return nil, fmt.Errorf("post request failed: %w", err)
+	}
+
+	if err := common.CheckResponse(res, http.StatusCreated); err != nil {
+		return nil, err
+	}
+
+	return policyFromResponse(res)
+}
+
+// ActivatePolicy activates a previously created policy with the policyID UUID,
+// associated with the specified scheme. This deactivates any previously-active
+// policy.
+func (o *Service) ActivatePolicy(scheme string, policyID uuid.UUID) error {
+	postURI := o.EndPointURI.JoinPath("policy", scheme, policyID.String(), "activate")
+
+	res, err := o.Client.PostEmptyResource(PolicyMediaType, postURI.String())
+	if err != nil {
+		return fmt.Errorf("post request failed: %w", err)
+	}
+
+	if err := common.CheckResponse(res, http.StatusOK); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeactivateAllPolicies deactivates all policies associated with the specified
+// scheme.
+func (o *Service) DeactivateAllPolicies(scheme string) error {
+	postURI := o.EndPointURI.JoinPath("policies", scheme, "deactivate")
+
+	res, err := o.Client.PostEmptyResource(PolicyMediaType, postURI.String())
+	if err != nil {
+		return fmt.Errorf("post request failed: %w", err)
+	}
+
+	if err := common.CheckResponse(res, http.StatusOK); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetActivePolicy returns the currently active policy for the specified
+// scheme. If no such policy exists, an error is returned.
+func (o *Service) GetActivePolicy(scheme string) (*Policy, error) {
+	getURI := o.EndPointURI.JoinPath("policy", scheme)
+
+	res, err := o.Client.GetResource(PolicyMediaType, getURI.String())
+	if err != nil {
+		return nil, fmt.Errorf("get request failed: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP response code %d", res.StatusCode)
+	}
+
+	return policyFromResponse(res)
+}
+
+// GetPolicy returns the policy with the specified UUID associated with the
+// specified scheme.
+func (o *Service) GetPolicy(scheme string, policyID uuid.UUID) (*Policy, error) {
+	getURI := o.EndPointURI.JoinPath("policy", scheme, policyID.String())
+
+	res, err := o.Client.GetResource(PolicyMediaType, getURI.String())
+	if err != nil {
+		return nil, fmt.Errorf("get request failed: %w", err)
+	}
+
+	if err := common.CheckResponse(res, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	return policyFromResponse(res)
+}
+
+// GetPolicies returns all policies associated with the specified scheme. If
+// the name is specified as something other than "", only policies with that
+// name are returned.
+func (o *Service) GetPolicies(scheme string, name string) ([]*Policy, error) {
+	getURI := o.EndPointURI.JoinPath("policies", scheme)
+
+	qvals := url.Values{}
+	if name != "" {
+		qvals.Add("name", name)
+	}
+	getURI.RawQuery = qvals.Encode()
+
+	res, err := o.Client.GetResource(PoliciesMediaType, getURI.String())
+	if err != nil {
+		return nil, fmt.Errorf("get request failed: %w", err)
+	}
+
+	if err := common.CheckResponse(res, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	return policiesFromResponse(res)
+}
+
+// GetSupportedSchemes returns a []string with the names of schemes supported
+// by the service.
+func (o *Service) GetSupportedSchemes() ([]string, error) {
+	wellKnownURI := &url.URL{
+		Scheme: o.EndPointURI.Scheme,
+		Host:   o.EndPointURI.Host,
+		Path:   WellKnownPath,
+	}
+
+	res, err := o.Client.GetResource(WellKnownMediaType, wellKnownURI.String())
+	if err != nil {
+		return nil, fmt.Errorf("get request failed: %w", err)
+	}
+
+	if err := common.CheckResponse(res, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	var schemesInfo struct {
+		Schemes []string `json:"attestation-schemes"`
+	}
+
+	if err := common.DecodeJSONBody(res, &schemesInfo); err != nil {
+		return nil, fmt.Errorf(
+			"could not decode well-known info response (status %d): %w",
+			res.StatusCode,
+			err,
+		)
+	}
+
+	return schemesInfo.Schemes, nil
+
+}
+
+func policyFromResponse(res *http.Response) (*Policy, error) {
+	if res.ContentLength == 0 {
+		return nil, errors.New("empty body")
+	}
+
+	ct := res.Header.Get("Content-Type")
+	if ct != PolicyMediaType {
+		return nil, fmt.Errorf(
+			"policy response with unexpected content type: %q", ct,
+		)
+	}
+
+	var policy Policy
+
+	if err := common.DecodeJSONBody(res, &policy); err != nil {
+		return nil, fmt.Errorf("failure decoding policy: %w", err)
+	}
+
+	return &policy, nil
+}
+
+func policiesFromResponse(res *http.Response) ([]*Policy, error) {
+	if res.ContentLength == 0 {
+		return nil, errors.New("empty body")
+	}
+
+	ct := res.Header.Get("Content-Type")
+	if ct != PoliciesMediaType {
+		return nil, fmt.Errorf(
+			"policies response with unexpected content type: %q", ct,
+		)
+	}
+
+	var policies []*Policy
+
+	if err := common.DecodeJSONBody(res, &policies); err != nil {
+		return nil, fmt.Errorf("failure decoding policies: %w", err)
+	}
+
+	return policies, nil
+}

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -1,0 +1,214 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/apiclient/common"
+)
+
+var (
+	testEndpointURI = &url.URL{
+		Scheme: "http",
+		Host:   "veraison.example",
+		Path:   "/management/v1",
+	}
+
+	testPolicy = &Policy{
+		Type:  "opa",
+		UUID:  uuid.New(),
+		Rules: "test rule",
+		Name:  "test_name",
+	}
+)
+
+func TestService_NewService(t *testing.T) {
+	_, err := NewService(string([]byte{0x7f}))
+	assert.EqualError(t, err, "malformed URI: parse \"\\x7f\": net/url: invalid control character in URL")
+
+	_, err = NewService("test")
+	assert.EqualError(t, err, "URI is not absolute: \"test\"")
+
+	service, err := NewService("http://veraison.example:9999/test/v1")
+	assert.NoError(t, err)
+	assert.Equal(t, "veraison.example:9999", service.EndPointURI.Host)
+}
+
+func TestService_CreateOPAPolicy(t *testing.T) {
+	expectedURI := testEndpointURI.JoinPath("policy", "test_scheme")
+	expectedURI.RawQuery = "name=test_name"
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, OPARulesMediaType, r.Header.Get("Content-Type"))
+		assert.Equal(t, PolicyMediaType, r.Header.Get("Accept"))
+		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
+
+		w.Header().Add("Content-Type", PolicyMediaType)
+		w.WriteHeader(http.StatusCreated)
+		_, err := w.Write(toBytes(testPolicy))
+		assert.NoError(t, err)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	service := Service{
+		EndPointURI: testEndpointURI,
+		Client:      client,
+	}
+
+	pol, err := service.CreateOPAPolicy("test_scheme", []byte{}, "test_name")
+	require.NoError(t, err)
+	assert.Equal(t, pol.Name, testPolicy.Name)
+	assert.Equal(t, pol.UUID, testPolicy.UUID)
+}
+
+func TestService_ActivatePolicy(t *testing.T) {
+	id := uuid.New()
+
+	expectedURI := testEndpointURI.JoinPath("policy", "test_scheme", id.String(), "activate")
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte{})
+		assert.NoError(t, err)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	service := Service{
+		EndPointURI: testEndpointURI,
+		Client:      client,
+	}
+
+	err := service.ActivatePolicy("test_scheme", id)
+	require.NoError(t, err)
+}
+
+func TestService_DeactivateAllPolicies(t *testing.T) {
+	expectedURI := testEndpointURI.JoinPath("policies", "test_scheme", "deactivate")
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte{})
+		assert.NoError(t, err)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	service := Service{
+		EndPointURI: testEndpointURI,
+		Client:      client,
+	}
+
+	err := service.DeactivateAllPolicies("test_scheme")
+	require.NoError(t, err)
+}
+
+func TestService_GetActivePolicy(t *testing.T) {
+	expectedURI := testEndpointURI.JoinPath("policy", "test_scheme")
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, PolicyMediaType, r.Header.Get("Accept"))
+		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
+
+		w.Header().Add("Content-Type", PolicyMediaType)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(toBytes(testPolicy))
+		assert.NoError(t, err)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	service := Service{
+		EndPointURI: testEndpointURI,
+		Client:      client,
+	}
+
+	pol, err := service.GetActivePolicy("test_scheme")
+	require.NoError(t, err)
+	assert.Equal(t, pol.Name, testPolicy.Name)
+	assert.Equal(t, pol.UUID, testPolicy.UUID)
+}
+
+func TestService_GetPolicy(t *testing.T) {
+	expectedURI := testEndpointURI.JoinPath("policy", "test_scheme", testPolicy.UUID.String())
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, PolicyMediaType, r.Header.Get("Accept"))
+		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
+
+		w.Header().Add("Content-Type", PolicyMediaType)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(toBytes(testPolicy))
+		assert.NoError(t, err)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	service := Service{
+		EndPointURI: testEndpointURI,
+		Client:      client,
+	}
+
+	pol, err := service.GetPolicy("test_scheme", testPolicy.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, pol.Name, testPolicy.Name)
+	assert.Equal(t, pol.UUID, testPolicy.UUID)
+}
+
+func TestService_GetPolicies(t *testing.T) {
+	expectedURI := testEndpointURI.JoinPath("policies", "test_scheme")
+	expectedURI.RawQuery = "name=test_name"
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, PoliciesMediaType, r.Header.Get("Accept"))
+		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
+
+		w.Header().Add("Content-Type", PoliciesMediaType)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(toBytes([]*Policy{testPolicy}))
+		assert.NoError(t, err)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	service := Service{
+		EndPointURI: testEndpointURI,
+		Client:      client,
+	}
+
+	pols, err := service.GetPolicies("test_scheme", "test_name")
+	require.NoError(t, err)
+	assert.Len(t, pols, 1)
+	assert.Equal(t, pols[0].Name, testPolicy.Name)
+	assert.Equal(t, pols[0].UUID, testPolicy.UUID)
+}
+
+func toBytes(in interface{}) []byte {
+	b, err := json.Marshal(in)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/management/policy.go
+++ b/management/policy.go
@@ -1,0 +1,34 @@
+package management
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Policy allows enforcing additional constraints on top of the regular
+// attestation schemes.
+type Policy struct {
+	// UUID is the unque identifier associated with this specific instance
+	// of a policy.
+	UUID uuid.UUID `json:"uuid"`
+
+	// CTime is the creationg time of this policy.
+	CTime time.Time `json:"ctime"`
+
+	// Name is the name of this policy. It's a short descritor for the
+	// rules in this policy.
+	Name string `json:"name"`
+
+	// Type identifies the policy engine used to evaluate the policy, and
+	// therfore dictates how the Rules should be interpreted.
+	Type string `json:"type"`
+
+	// Rules of the policy to be interpreted and execute by the policy
+	// agent.
+	Rules string `json:"rules"`
+
+	// Active indicates whether this policy instance is currently active
+	// for the associated key.
+	Active bool `json:"active"`
+}

--- a/verification/challengeresponse_test.go
+++ b/verification/challengeresponse_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -864,7 +863,7 @@ func TestChallengeResponseConfig_Run_async_CMWWrap(t *testing.T) {
 				iter++
 			case 2:
 				assert.Equal(t, http.MethodPost, r.Method)
-				ev, err := ioutil.ReadAll(r.Body)
+				ev, err := io.ReadAll(r.Body)
 				require.Nil(t, err)
 				assert.Equal(t, ev, tv.ev)
 				assert.Equal(t, r.Header.Get("Content-Type"), tv.ct)


### PR DESCRIPTION
- Extend common.Client with PostEmptyResource() and GetResource() methods.
- Add ProblemError, an Error interface wrapper around RFC7807 problems.
- Implement the policy management service API support.