### PR TITLE
feat: add TLS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GO111MODULE := on
 
 GOPKG := github.com/veraison/apiclient/verification
 GOPKG += github.com/veraison/apiclient/provisioning
+GOPKG += github.com/veraison/apiclient/management
 
 GOLINT ?= golangci-lint
 

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -39,6 +39,26 @@ func TestService_NewService(t *testing.T) {
 	assert.Equal(t, "veraison.example:9999", service.EndPointURI.Host)
 }
 
+func TestService_TLS_NewTLSService(t *testing.T) {
+	_, err := NewTLSService("http://veraison.example:9999/test/v1", nil, nil)
+	assert.Contains(t, err.Error(), "expected HTTPS scheme")
+
+	service, err := NewTLSService("https://veraison.example:9999/test/v1", nil, nil)
+	require.NoError(t, err)
+	transport := service.Client.HTTPClient.Transport.(*http.Transport)
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestService_TLS_NewInsecureTLSService(t *testing.T) {
+	_, err := NewInsecureTLSService("http://veraison.example:9999/test/v1", nil)
+	assert.Contains(t, err.Error(), "expected HTTPS scheme")
+
+	service, err := NewInsecureTLSService("https://veraison.example:9999/test/v1", nil)
+	require.NoError(t, err)
+	transport := service.Client.HTTPClient.Transport.(*http.Transport)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
 func TestService_CreateOPAPolicy(t *testing.T) {
 	expectedURI := testEndpointURI.JoinPath("policy", "test_scheme")
 	expectedURI.RawQuery = "name=test_name"

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -19,6 +19,12 @@ var (
 		Path:   "/management/v1",
 	}
 
+	testWellKnownURI = &url.URL{
+		Scheme: "http",
+		Host:   "veraison.example",
+		Path:   WellKnownPath,
+	}
+
 	testPolicy = &Policy{
 		Type:  "opa",
 		UUID:  uuid.New(),
@@ -57,6 +63,18 @@ func TestService_TLS_NewInsecureTLSService(t *testing.T) {
 	require.NoError(t, err)
 	transport := service.Client.HTTPClient.Transport.(*http.Transport)
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestService_SetClient(t *testing.T) {
+	service, err := NewService("http://veraison.example:9999/test/v1", nil)
+	require.NoError(t, err)
+
+	err = service.SetClient(nil)
+	assert.EqualError(t, err, "no client supplied")
+
+	client := common.NewClient(nil)
+	err = service.SetClient(client)
+	assert.NoError(t, err)
 }
 
 func TestService_CreateOPAPolicy(t *testing.T) {
@@ -170,15 +188,28 @@ func TestService_GetActivePolicy(t *testing.T) {
 func TestService_GetPolicy(t *testing.T) {
 	expectedURI := testEndpointURI.JoinPath("policy", "test_scheme", testPolicy.UUID.String())
 
+	test := "ok"
+
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, PolicyMediaType, r.Header.Get("Accept"))
 		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
 
-		w.Header().Add("Content-Type", PolicyMediaType)
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write(toBytes(testPolicy))
-		assert.NoError(t, err)
+		switch test {
+		case "ok":
+			w.Header().Add("Content-Type", PolicyMediaType)
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(toBytes(testPolicy))
+			assert.NoError(t, err)
+		case "empty":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusOK)
+		case "server-error":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			require.Fail(t, "unexpected test value: %q", test)
+		}
 	})
 
 	client, teardown := common.NewTestingHTTPClient(h)
@@ -193,21 +224,42 @@ func TestService_GetPolicy(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pol.Name, testPolicy.Name)
 	assert.Equal(t, pol.UUID, testPolicy.UUID)
+
+	test = "empty"
+	_, err = service.GetPolicy("test_scheme", testPolicy.UUID)
+	assert.Contains(t, err.Error(), "empty body")
+
+	test = "server-error"
+	_, err = service.GetPolicy("test_scheme", testPolicy.UUID)
+	assert.Contains(t, err.Error(), "unexpected HTTP response code 500")
 }
 
 func TestService_GetPolicies(t *testing.T) {
 	expectedURI := testEndpointURI.JoinPath("policies", "test_scheme")
 	expectedURI.RawQuery = "name=test_name"
 
+	test := "ok"
+
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, PoliciesMediaType, r.Header.Get("Accept"))
 		assert.Equal(t, expectedURI.RequestURI(), r.RequestURI)
 
-		w.Header().Add("Content-Type", PoliciesMediaType)
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write(toBytes([]*Policy{testPolicy}))
-		assert.NoError(t, err)
+		switch test {
+		case "ok":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(toBytes([]*Policy{testPolicy}))
+			assert.NoError(t, err)
+		case "empty":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusOK)
+		case "server-error":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			require.Fail(t, "unexpected test value: %q", test)
+		}
 	})
 
 	client, teardown := common.NewTestingHTTPClient(h)
@@ -223,6 +275,73 @@ func TestService_GetPolicies(t *testing.T) {
 	assert.Len(t, pols, 1)
 	assert.Equal(t, pols[0].Name, testPolicy.Name)
 	assert.Equal(t, pols[0].UUID, testPolicy.UUID)
+
+	test = "empty"
+	_, err = service.GetPolicies("test_scheme", "test_name")
+	assert.EqualError(t, err, "empty body")
+
+	test = "server-error"
+	_, err = service.GetPolicies("test_scheme", "test_name")
+	assert.Contains(t, err.Error(), "unexpected HTTP response code 500")
+}
+
+func TestService_GetSupportedSchemes(t *testing.T) {
+	test := "ok"
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, WellKnownMediaType, r.Header.Get("Accept"))
+		assert.Equal(t, testWellKnownURI.RequestURI(), r.RequestURI)
+
+		switch test {
+		case "ok":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusOK)
+
+			wellKnownInfo := `
+			{
+			    "attestation-schemes": [
+				"scheme1",
+				"scheme2"
+			    ]
+			}
+			`
+			_, err := w.Write([]byte(wellKnownInfo))
+			assert.NoError(t, err)
+		case "bad-resp-format":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusOK)
+
+			wellKnownInfo := `""`
+			_, err := w.Write([]byte(wellKnownInfo))
+			assert.NoError(t, err)
+		case "server-error":
+			w.Header().Add("Content-Type", PoliciesMediaType)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			require.Fail(t, "unexpected test value: %q", test)
+		}
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	service := Service{
+		EndPointURI: testEndpointURI,
+		Client:      client,
+	}
+
+	schemes, err := service.GetSupportedSchemes()
+	require.NoError(t, err)
+	assert.EqualValues(t, []string{"scheme1", "scheme2"}, schemes)
+
+	test = "bad-resp-format"
+	_, err = service.GetSupportedSchemes()
+	assert.Contains(t, err.Error(), "could not decode well-known info")
+
+	test = "server-error"
+	_, err = service.GetSupportedSchemes()
+	assert.Contains(t, err.Error(), "unexpected HTTP response code 500")
 }
 
 func toBytes(in interface{}) []byte {


### PR DESCRIPTION
Add support for connecting to the service using TLS. Optionally, certification validation may be disabled.

Also fix Makefile so that `management` tests now run as part of `make test` and add tests to improve coverage.