### PR TITLE
fix!: base64url-encoded nonce

### DIFF
--- a/verification/challengeresponse.go
+++ b/verification/challengeresponse.go
@@ -283,7 +283,7 @@ func (cfg ChallengeResponseConfig) newSessionRequest() (*http.Response, error) {
 	// nonceSize=32)
 	q := req.URL.Query()
 	if len(cfg.Nonce) > 0 {
-		q.Set("nonce", base64.StdEncoding.EncodeToString(cfg.Nonce))
+		q.Set("nonce", base64.URLEncoding.EncodeToString(cfg.Nonce))
 	} else if cfg.NonceSz > 0 {
 		q.Set("nonceSize", fmt.Sprint(cfg.NonceSz))
 	}

--- a/verification/challengeresponse_test.go
+++ b/verification/challengeresponse_test.go
@@ -137,7 +137,7 @@ func TestChallengeResponseConfig_NewSession_ok(t *testing.T) {
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "3q2+7w==", r.URL.Query().Get("nonce"))
+		assert.Equal(t, "3q2-7w==", r.URL.Query().Get("nonce"))
 		assert.Equal(t, "application/vnd.veraison.challenge-response-session+json", r.Header.Get("Accept"))
 
 		w.Header().Set("Location", expectedSessionURI)
@@ -251,7 +251,7 @@ func TestChallengeResponseConfig_NewSession_relative_location_ok(t *testing.T) {
 	relativeSessionURI := testRelSessionURI
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "3q2+7w==", r.URL.Query().Get("nonce"))
+		assert.Equal(t, "3q2-7w==", r.URL.Query().Get("nonce"))
 		assert.Equal(t, "application/vnd.veraison.challenge-response-session+json", r.Header.Get("Accept"))
 
 		w.Header().Set("Location", relativeSessionURI)
@@ -821,7 +821,7 @@ func synthesizeSession(mt string, ev []byte) []string {
     }
 }`,
 	}
-	evs := base64.StdEncoding.EncodeToString(ev)
+	evs := base64.URLEncoding.EncodeToString(ev)
 	s[1] = fmt.Sprintf(s[1], mt, evs)
 	s[2] = fmt.Sprintf(s[2], evs)
 	return s


### PR DESCRIPTION
verification API expects the nonce to be b64url-encoded