### PR TITLE
Fix Issue #14: Return success information from SubmitConfig.Run()

### DIFF
--- a/provisioning/doc.go
+++ b/provisioning/doc.go
@@ -36,8 +36,10 @@ trigger the protocol FSM, hiding any details about the synchronus / async nature
 of the underlying exchange.  The user must supply the byte buffer containing the
 serialized endorsement, and the associated media type:
 
-	err := cfg.Run(corimBuf, "application/corim+cbor")
+	session, err := cfg.Run(corimBuf, "application/corim+cbor")
 
-On success err is nil.
+On success, session contains the final submission status and err is nil.
+The session object provides details like status, expiry time, and other
+submission information that can be displayed to the user.
 */
 package provisioning


### PR DESCRIPTION
 
##  Issue Reference
Fixes: [#14 - Investigate whether Provisioning API Client Return Code on Success](https://github.com/veraison/apiclient/issues/14)

##  Problem Description
The original `SubmitConfig.Run()` method only returned an `error`, providing no success information to callers when CoRIM submission succeeded. This made it impossible for applications to display meaningful success messages or status information to users.

##  Solution
Changed the API signature to return both success information and errors:

**Before:**
```go
func (cfg SubmitConfig) Run(endorsement []byte, mediaType string) error
```

**After:**
```go
func (cfg SubmitConfig) Run(endorsement []byte, mediaType string) (*SubmitSession, error)
```

##  Benefits
-  **Success Information Access**: Callers can now access status, expiry time, and other session details
-  **User-Friendly Feedback**: Applications can display meaningful success messages
-  **Both Sync & Async Support**: Works for synchronous and asynchronous submissions
-  **Rich Status Details**: Access to complete session information from server

##  Files Changed
- `provisioning/provisioning.go` - Updated `Run()` and `pollForSubmissionCompletion()` methods
- `provisioning/doc.go` - Updated package documentation 
- `provisioning/provisioning_test.go` - Updated all tests + added success info demonstration tests

##  Testing
### New Tests Added:
- `TestSubmitConfig_Run_success_info_returned` - Demonstrates synchronous success info access
- `TestSubmitConfig_Run_async_success_info_returned` - Demonstrates asynchronous success info access

### Test Results:
```
 All existing tests updated and passing
 New success info tests pass with example output:
    CoRIM successfully submitted! Status: success, Expires: 2030-12-25T10:30:45.123Z
    CoRIM async submission completed! Status: success, Expires: 2030-12-25T10:30:45.123Z
```

##  Usage Example
```go
// OLD (Issue #14 problem)
err := cfg.Run(corimBuf, "application/corim+cbor")
if err != nil {
    log.Fatal(err)
}
//  No success information available

// NEW (Issue #14 fixed)
session, err := cfg.Run(corimBuf, "application/corim+cbor")
if err != nil {
    log.Fatal(err)
}
//  Rich success information now available!
fmt.Printf(" CoRIM successfully submitted!\n")
fmt.Printf("   Status: %s\n", session.Status)
fmt.Printf("   Expires: %s\n", session.Expiry)
```

##  Breaking Change Notice
This is a breaking API change, but it directly addresses the core issue #14.

**Migration Path:**
```go
// Before
err := cfg.Run(data, mediaType)

// After  
session, err := cfg.Run(data, mediaType)
// Now you have access to session.Status, session.Expiry, etc.
```
 