### PR TITLE
feat(coserv): added HTTP caching (RFC 9111) functionality for coserv …

### DIFF
--- a/coserv/coserv.go
+++ b/coserv/coserv.go
@@ -11,6 +11,9 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/bartventer/httpcache"
+	_ "github.com/bartventer/httpcache/store/memcache"
+
 	"github.com/veraison/apiclient/auth"
 	"github.com/veraison/apiclient/common"
 	"github.com/veraison/corim/coserv"
@@ -31,6 +34,7 @@ type QueryConfig struct {
 	Auth       auth.IAuthenticator // request authentication
 	UseTLS     bool                // whether to use TLS
 	IsInsecure bool                // skip TLS verification
+	Cache      bool                // Enable HTTP caching of reponses (RFC 9111)
 
 	RequestResponseURI *uritemplate.Template // URL template ending with "{query}"
 }
@@ -84,6 +88,11 @@ func (cfg *QueryConfig) SetAuth(a auth.IAuthenticator) {
 // SetIsInsecure disables TLS certificate validation (similar to DiscoveryClientBuilder).
 func (cfg *QueryConfig) SetIsInsecure(val bool) {
 	cfg.IsInsecure = val
+}
+
+// EnableCache enables/disables HTTP Caching (RFC 9111).
+func (cfg *QueryConfig) EnableCache(val bool) {
+	cfg.Cache = val
 }
 
 // SetCerts sets CA certificate paths.
@@ -177,20 +186,70 @@ func (cfg *QueryConfig) check() error {
 
 // initClient creates a default client if none supplied.
 func (cfg *QueryConfig) initClient() error {
-	if cfg.Client != nil {
-		return nil
+	if cfg.Client == nil {
+		if !cfg.UseTLS {
+			cfg.Client = common.NewClient(cfg.Auth)
+		} else if cfg.IsInsecure {
+			cfg.Client = common.NewInsecureTLSClient(cfg.Auth)
+			return nil
+		} else {
+			var err error
+			if cfg.Client, err = common.NewTLSClient(cfg.Auth, cfg.CACerts); err != nil {
+				return err
+			}
+		}
 	}
-	if !cfg.UseTLS {
-		cfg.Client = common.NewClient(cfg.Auth)
-		return nil
+
+	// Enable caching if config is set
+	if cfg.Cache {
+		if err := addCache(cfg.Client); err != nil {
+			return err
+		}
 	}
-	if cfg.IsInsecure {
-		cfg.Client = common.NewInsecureTLSClient(cfg.Auth)
-		return nil
+	return nil
+}
+
+type cachedTransport struct {
+	http.RoundTripper
+}
+
+// Add memory based cache round tripper
+func addCacheRoundTripper(c *common.Client) (err error) {
+	defer func() { // Function to recover gracefully from ErrOpenCache panic
+		if r := recover(); r != nil {
+			err = fmt.Errorf("caching layer addition failed with error: %w", err)
+		}
+	}()
+
+	base := c.HTTPClient.Transport
+
+	rt := httpcache.NewTransport(
+		"memcache://",
+		httpcache.WithUpstream(base),
+		httpcache.WithSWRTimeout(0),
+	)
+
+	c.HTTPClient.Transport = &cachedTransport{
+		RoundTripper: rt,
 	}
-	var err error
-	cfg.Client, err = common.NewTLSClient(cfg.Auth, cfg.CACerts)
-	return err
+
+	return nil
+}
+
+// Add Cache Transport Middleware
+func addCache(c *common.Client) (err error) {
+	if c == nil {
+		err = errors.New("failed to add cache layer, client is empty")
+		return
+	}
+
+	if c.HTTPClient.Transport != nil {
+		if _, ok := c.HTTPClient.Transport.(*cachedTransport); ok {
+			return nil // The client transport is already wrapped
+		}
+	}
+
+	return addCacheRoundTripper(c)
 }
 
 // ExtractCoservFromSignedResponse verifies the raw signed Coserv data using the provided Cose Verifiers.

--- a/coserv/coserv_test.go
+++ b/coserv/coserv_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -193,6 +194,13 @@ func TestQueryConfig_SetIsInsecure(t *testing.T) {
 	assert.True(t, cfg.IsInsecure)
 }
 
+func TestQueryConfig_EnableCache(t *testing.T) {
+	cfg := QueryConfig{}
+	assert.False(t, cfg.Cache)
+	cfg.EnableCache(true)
+	assert.True(t, cfg.Cache)
+}
+
 func TestQueryConfig_SetCerts(t *testing.T) {
 	cfg := QueryConfig{}
 	_ = cfg.SetCerts(testCACerts)
@@ -226,6 +234,27 @@ func TestQueryConfig_initClient_already_set(t *testing.T) {
 	err := cfg.initClient()
 	assert.NoError(t, err)
 	assert.Equal(t, customClient, cfg.Client)
+}
+
+func TestQueryConfig_initClient_with_cache(t *testing.T) {
+	cfg := QueryConfig{
+		Cache: true,
+	}
+	err := cfg.initClient()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.Client)
+	_, ok := cfg.Client.HTTPClient.Transport.(*cachedTransport)
+	assert.True(t, ok)
+}
+
+func TestAddCache(t *testing.T) {
+	err := addCache(nil)
+	assert.EqualError(t, err, "failed to add cache layer, client is empty")
+	customClient := common.NewClient(nil)
+	err = addCache(customClient)
+	assert.NoError(t, err)
+	_, ok := customClient.HTTPClient.Transport.(*cachedTransport)
+	assert.True(t, ok)
 }
 
 func TestQueryConfig_RunQueryForUnsignedResponse_Success(t *testing.T) {
@@ -497,4 +526,77 @@ func TestExtractCoservFromSignedResponse_InvalidPayload(t *testing.T) {
 	_, err = ExtractCoservFromSignedResponse(signedData, []cose.Verifier{verifier})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "signature verification failed with all keys")
+}
+
+// Testing cache with 60 seconds Max Age
+func TestQueryConfig_WithCache(t *testing.T) {
+	var hitCount int32
+	respCBOR, err := newDefaultResponse().ToCBOR()
+	require.NoError(t, err)
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
+		assert.Equal(t, UnsignedCoSERVMediaType, r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", UnsignedCoSERVMediaType)
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respCBOR)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	cfg := QueryConfig{}
+	err = cfg.SetRequestResponseURI(testRequestResponseURI)
+	require.NoError(t, err)
+	err = cfg.SetClient(client)
+	require.NoError(t, err)
+
+	cfg.EnableCache(true)
+
+	result, err := cfg.RunQueryForUnsignedResponse(newDefaultQuery())
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	result, err = cfg.RunQueryForUnsignedResponse(newDefaultQuery())
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	assert.Equal(t, atomic.LoadInt32(&hitCount), int32(1))
+}
+
+func TestQueryConfig_WithoutCache(t *testing.T) {
+	var hitCount int32
+	respCBOR, err := newDefaultResponse().ToCBOR()
+	require.NoError(t, err)
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
+		assert.Equal(t, UnsignedCoSERVMediaType, r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", UnsignedCoSERVMediaType)
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respCBOR)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	cfg := QueryConfig{}
+	err = cfg.SetRequestResponseURI(testRequestResponseURI)
+	require.NoError(t, err)
+	err = cfg.SetClient(client)
+	require.NoError(t, err)
+
+	cfg.EnableCache(false)
+
+	result, err := cfg.RunQueryForUnsignedResponse(newDefaultQuery())
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	result, err = cfg.RunQueryForUnsignedResponse(newDefaultQuery())
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	assert.Equal(t, atomic.LoadInt32(&hitCount), int32(2))
 }

--- a/coserv/discovery.go
+++ b/coserv/discovery.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package coserv // or keep in package coserv if preferred
+package coserv
 
 import (
 	"errors"
@@ -35,6 +35,7 @@ type DiscoveryConfig struct {
 	client       *common.Client // optional preconfigured HTTP client
 	useTLS       bool           // whether the scheme is https (set automatically from URI)
 	isInsecure   bool           // skip TLS verification (only when useTLS == true)
+	cache        bool           // Enable HTTP caching of reponses (RFC 9111)
 }
 
 // SetDiscoveryURI sets the base server URL. It must be absolute.
@@ -54,6 +55,11 @@ func (cfg *DiscoveryConfig) SetDiscoveryURI(uri string) error {
 // SetIsInsecure enables insecure TLS connections (skip verification).
 func (cfg *DiscoveryConfig) SetIsInsecure(val bool) {
 	cfg.isInsecure = val
+}
+
+// EnableCache enables/disables HTTP Caching (RFC 9111)
+func (cfg *DiscoveryConfig) EnableCache(val bool) {
+	cfg.cache = val
 }
 
 // SetCerts sets additional CA certificate file paths.
@@ -161,20 +167,26 @@ func (cfg *DiscoveryConfig) check() error {
 
 // initClient creates a default common.Client if none was provided.
 func (cfg *DiscoveryConfig) initClient() error {
-	if cfg.client != nil {
-		return nil
+	if cfg.client == nil {
+		if !cfg.useTLS {
+			cfg.client = common.NewClient(nil) // no authenticator, no TLS
+		} else if cfg.isInsecure {
+			cfg.client = common.NewInsecureTLSClient(nil)
+		} else {
+			var err error
+			if cfg.client, err = common.NewTLSClient(nil, cfg.caCerts); err != nil {
+				return err
+			}
+		}
 	}
-	if !cfg.useTLS {
-		cfg.client = common.NewClient(nil) // no authenticator, no TLS
-		return nil
+
+	// Enable caching if config is set
+	if cfg.cache {
+		if err := addCache(cfg.client); err != nil {
+			return err
+		}
 	}
-	if cfg.isInsecure {
-		cfg.client = common.NewInsecureTLSClient(nil)
-		return nil
-	}
-	var err error
-	cfg.client, err = common.NewTLSClient(nil, cfg.caCerts)
-	return err
+	return nil
 }
 
 // doRequest constructs the HTTP GET request to the well‑known discovery endpoint.

--- a/coserv/discovery_test.go
+++ b/coserv/discovery_test.go
@@ -6,6 +6,7 @@ package coserv
 import (
 	"encoding/json"
 	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,13 @@ func TestDiscoveryConfig_SetIsInsecure(t *testing.T) {
 	assert.True(t, cfg.isInsecure)
 }
 
+func TestDiscoveryConfig_EnableCache(t *testing.T) {
+	cfg := &DiscoveryConfig{}
+	assert.False(t, cfg.cache)
+	cfg.EnableCache(true)
+	assert.True(t, cfg.cache)
+}
+
 func TestDiscoveryConfig_SetCerts_Valid(t *testing.T) {
 	cfg := &DiscoveryConfig{}
 	err := cfg.SetCerts([]string{"/path/to/ca1.pem", "/path/to/ca2.pem"})
@@ -78,8 +86,11 @@ func TestDiscoveryConfig_SetClient_Nil(t *testing.T) {
 	assert.Nil(t, cfg.client)
 }
 
-func TestDiscoveryConfig_Run_Success(t *testing.T) {
+// Testing success response with cache (60 seconds Max Age)
+func TestDiscoveryConfig_Run_Success_WithCache(t *testing.T) {
+	var hitCount int32
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
 		assert.Equal(t, DiscoveryMediaTypeJson, r.Header.Get("Accept"))
 
 		doc := coserv.DiscoveryDocument{}
@@ -88,6 +99,7 @@ func TestDiscoveryConfig_Run_Success(t *testing.T) {
 		doc.AddCapability("application/coserv+cbor", []coserv.ArtifactSupport{coserv.ArtifactSupportCollected})
 		doc.AddEndPoint("CoSERVRequestResponse", "/endpoint/{query}")
 		w.Header().Set("Content-Type", DiscoveryMediaTypeJson)
+		w.Header().Set("Cache-Control", "max-age=60")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(doc)
 	})
@@ -101,13 +113,62 @@ func TestDiscoveryConfig_Run_Success(t *testing.T) {
 	err = cfg.SetClient(client)
 	require.NoError(t, err)
 
+	cfg.EnableCache(true)
+
 	result, err := cfg.Run()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	result, err = cfg.Run()
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
 	assert.Equal(t, "1.2.3", result.Version)
 	assert.Contains(t, result.ApiEndPointsMap, "CoSERVRequestResponse")
 	assert.Equal(t, testBaseURI+"/endpoint/{query}", result.QueryEndpointURL)
+	assert.Equal(t, atomic.LoadInt32(&hitCount), int32(1))
+}
+
+func TestDiscoveryConfig_Run_Success_WithoutCache(t *testing.T) {
+	var hitCount int32
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
+		assert.Equal(t, DiscoveryMediaTypeJson, r.Header.Get("Accept"))
+
+		doc := coserv.DiscoveryDocument{}
+		doc.SetVersion("1.2.3")
+
+		doc.AddCapability("application/coserv+cbor", []coserv.ArtifactSupport{coserv.ArtifactSupportCollected})
+		doc.AddEndPoint("CoSERVRequestResponse", "/endpoint/{query}")
+		w.Header().Set("Content-Type", DiscoveryMediaTypeJson)
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(doc)
+	})
+
+	client, teardown := common.NewTestingHTTPClient(h)
+	defer teardown()
+
+	cfg := &DiscoveryConfig{}
+	err := cfg.SetDiscoveryURI(testBaseURI)
+	require.NoError(t, err)
+	err = cfg.SetClient(client)
+	require.NoError(t, err)
+
+	cfg.EnableCache(false)
+
+	result, err := cfg.Run()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	result, err = cfg.Run()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "1.2.3", result.Version)
+	assert.Contains(t, result.ApiEndPointsMap, "CoSERVRequestResponse")
+	assert.Equal(t, testBaseURI+"/endpoint/{query}", result.QueryEndpointURL)
+	assert.Equal(t, atomic.LoadInt32(&hitCount), int32(2))
 }
 
 func TestDiscoveryConfig_Run_NoDiscoveryURI(t *testing.T) {
@@ -247,6 +308,20 @@ func TestDiscoveryConfig_initClient_TLSInsecure(t *testing.T) {
 	err := cfg.initClient()
 	require.NoError(t, err)
 	assert.NotNil(t, cfg.client)
+}
+
+func TestDiscoveryConfig_initClient_WithCache(t *testing.T) {
+	cfg := &DiscoveryConfig{
+		discoveryURI: "https://example.com",
+		useTLS:       true,
+		isInsecure:   true,
+		cache:        true,
+	}
+	err := cfg.initClient()
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.client)
+	_, ok := cfg.client.HTTPClient.Transport.(*cachedTransport)
+	assert.True(t, ok)
 }
 
 func TestDiscoveryConfig_initClient_AlreadySet(t *testing.T) {

--- a/coserv/doc.go
+++ b/coserv/doc.go
@@ -15,6 +15,7 @@ use DiscoveryConfig:
 		// handle error
 	}
 	cfg.SetIsInsecure(true) // optional: skip TLS verification
+	cfg.EnableCache(true)   // optional: enable HTTP caching (RFC 9111)
 	if err := cfg.SetCerts([]string{"/path/to/ca.pem"}); err != nil {
 		// handle error
 	}
@@ -43,10 +44,11 @@ create a QueryConfig:
 		// handle error
 	}
 
-Optionally configure TLS, authentication, or a custom HTTP client:
+Optionally configure TLS, caching, authentication, or a custom HTTP client:
 
 	qcfg.SetCerts([]string{"/path/to/ca.pem"})
-	cfg.SetIsInsecure(true) // optional: skip TLS verification
+	qcfg.SetIsInsecure(true) // optional: skip TLS verification
+	qcfg.EnableCache(true)   // optional: enable HTTP caching (RFC 9111)
 	qcfg.SetAuth(myAuthenticator)
 
 Build a CoSERV query using the github.com/veraison/corim/coserv package:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/veraison/apiclient
 go 1.25.0
 
 require (
+	github.com/bartventer/httpcache v0.13.0
 	github.com/google/uuid v1.3.0
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/bartventer/httpcache v0.13.0 h1:gk/fqa87lHgmi3IXEtM6tHs+j7OR/c3Scb7b8pWF8yE=
+github.com/bartventer/httpcache v0.13.0/go.mod h1:AXVAaiITDQ83wjpI8TzzLior8A9VFq0cl3chDtQRpgU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
PR to add Add Memory based HTTP caching for Coserv Discovery & Query client. Using "memcache" feature from https://github.com/bartventer/httpcache. Caching feature can be enabled by calling respective setters.
Also addressed minor comments from last PR: https://github.com/veraison/apiclient/pull/39